### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,30 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+          - php: 8.3
+            os: ubuntu-latest
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.10
+            stability: prefer-lowest
+          - php: 8.4
+            os: ubuntu-latest
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.10
+            stability: prefer-lowest
+          - php: 8.3
+            os: ubuntu-latest
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.10
+            stability: prefer-stable
+          - php: 8.4
+            os: ubuntu-latest
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.10
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -39,6 +63,12 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Prepare Laravel 13 test dependencies
+        if: matrix.laravel == '13.*'
+        run: |
+          composer remove nunomaduro/larastan --dev --no-interaction --no-update
+          composer require "nunomaduro/collision:^8.9" "pestphp/pest:^4.4" "pestphp/pest-plugin-arch:^4.0" "pestphp/pest-plugin-laravel:^4.1" --dev --no-interaction --no-update
+
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
@@ -48,4 +78,9 @@ jobs:
         run: composer show -D
 
       - name: Execute tests
+        if: matrix.laravel != '13.*'
         run: vendor/bin/pest --ci
+
+      - name: Execute Laravel 13 tests
+        if: matrix.laravel == '13.*'
+        run: vendor/bin/pest --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.28 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/contracts": "^9.28 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- add Laravel 13 support to the illuminate/contracts constraint
- add Laravel 13 CI coverage on PHP 8.3 and 8.4 with Testbench 11
- adjust Laravel 13 CI test dependencies for Pest 4 compatibility

## Tests
- composer validate --strict
- YAML workflow parse check
- git diff --check
- Laravel 13 dependency resolution with prefer-stable and prefer-lowest
- Laravel 13 test run: vendor/bin/pest --no-coverage (2 passed, 4 assertions)
