### PR TITLE
Fix CI dependency matrix

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,7 +16,7 @@ jobs:
           # Skipped as incompatible:
           # - Laravel 9 on PHP 8.3, 8.4, 8.5: Laravel 9 test stack uses PHPUnit 9/Pest 1.
           # - Laravel 10 on PHP 8.0: Laravel 10 requires PHP 8.1+.
-          # - Laravel 10 on PHP 8.4, 8.5: Pest 2/Paratest 7.3 for Laravel 10 does not support PHP 8.4+.
+          # - Laravel 10 on PHP 8.4, 8.5: Pest 2/Paratest for Laravel 10 does not support PHP 8.4+.
           # - Laravel 11 and 12 on PHP 8.0, 8.1: Laravel 11/12 test stacks require PHP 8.2+.
           # - Laravel 13 on PHP 8.0, 8.1, 8.2: Laravel 13/Testbench 11 require PHP 8.3+.
           - os: ubuntu-latest
@@ -90,7 +90,7 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
+            collision: ^7.11
             pest: ^2.33.2 <2.33.3
             pest_laravel: ^2.0
             pest_arch: ^2.0
@@ -101,10 +101,10 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
+            collision: ^7.11
+            pest: ^2.35.1
+            pest_laravel: ^2.4
+            pest_arch: ^2.7
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -112,7 +112,7 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
+            collision: ^7.11
             pest: ^2.33.2 <2.33.3
             pest_laravel: ^2.0
             pest_arch: ^2.0
@@ -123,10 +123,10 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
+            collision: ^7.11
+            pest: ^2.36.1
+            pest_laravel: ^2.4
+            pest_arch: ^2.7
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -134,7 +134,7 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
+            collision: ^7.11
             pest: ^2.33.2 <2.33.3
             pest_laravel: ^2.0
             pest_arch: ^2.0
@@ -145,10 +145,10 @@ jobs:
             laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
-            collision: ^7.8
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
+            collision: ^7.11
+            pest: ^2.36.1
+            pest_laravel: ^2.4
+            pest_arch: ^2.7
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -157,9 +157,9 @@ jobs:
             testbench: 9.*
             carbon: ^2.72
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-lowest
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -168,9 +168,9 @@ jobs:
             testbench: 9.*
             carbon: ^2.72
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -179,9 +179,9 @@ jobs:
             testbench: 9.*
             carbon: ^2.72
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -190,9 +190,9 @@ jobs:
             testbench: 9.*
             carbon: ^2.72
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -201,9 +201,9 @@ jobs:
             testbench: 9.*
             carbon: ^2.72
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -212,9 +212,9 @@ jobs:
             testbench: 10.*
             carbon: ^3.8.4
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-lowest
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -223,9 +223,9 @@ jobs:
             testbench: 10.*
             carbon: ^3.8.4
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -234,9 +234,9 @@ jobs:
             testbench: 10.*
             carbon: ^3.8.4
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -245,9 +245,9 @@ jobs:
             testbench: 10.*
             carbon: ^3.8.4
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -256,9 +256,9 @@ jobs:
             testbench: 10.*
             carbon: ^3.8.4
             collision: ^8.9.1
-            pest: ^3.8.2
+            pest: ^3.8.6
             pest_laravel: ^3.2
-            pest_arch: ^3.1
+            pest_arch: ^3.1.1
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -267,9 +267,9 @@ jobs:
             testbench: 11.*
             carbon: ^3.8
             collision: ^8.9.4
-            pest: ^4.4.1
+            pest: ^4.7.0
             pest_laravel: ^4.1
-            pest_arch: ^4.0
+            pest_arch: ^4.0.2
             stability: prefer-lowest
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -278,9 +278,9 @@ jobs:
             testbench: 11.*
             carbon: ^3.8
             collision: ^8.9.4
-            pest: ^4.4.1
+            pest: ^4.7.0
             pest_laravel: ^4.1
-            pest_arch: ^4.0
+            pest_arch: ^4.0.2
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -289,9 +289,9 @@ jobs:
             testbench: 11.*
             carbon: ^3.8
             collision: ^8.9.4
-            pest: ^4.4.1
+            pest: ^4.7.0
             pest_laravel: ^4.1
-            pest_arch: ^4.0
+            pest_arch: ^4.0.2
             stability: prefer-stable
             test_command: vendor/bin/pest
           - os: ubuntu-latest
@@ -300,9 +300,9 @@ jobs:
             testbench: 11.*
             carbon: ^3.8
             collision: ^8.9.4
-            pest: ^4.4.1
+            pest: ^4.7.0
             pest_laravel: ^4.1
-            pest_arch: ^4.0
+            pest_arch: ^4.0.2
             stability: prefer-stable
             test_command: vendor/bin/pest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --dev --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,84 +10,24 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            php: 8.2
-            laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
-            collision: ^7.8
-            stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
-          - os: ubuntu-latest
-            php: 8.2
-            laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
-            collision: ^7.8
-            stability: prefer-stable
-            test_command: vendor/bin/pest --ci
-          - os: ubuntu-latest
-            php: 8.1
-            laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
-            collision: ^7.8
-            stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
-          - os: ubuntu-latest
-            php: 8.1
-            laravel: 10.*
-            testbench: 8.*
-            carbon: ^2.63
-            pest: ^2.33.2 <2.33.3
-            pest_laravel: ^2.0
-            pest_arch: ^2.0
-            collision: ^7.8
-            stability: prefer-stable
-            test_command: vendor/bin/pest --ci
-          - os: ubuntu-latest
-            php: 8.1
-            laravel: 9.*
-            testbench: 7.*
-            carbon: ^2.63
-            pest: ^1.23
-            pest_laravel: ^1.4
-            pest_arch: none
-            collision: ^6.4
-            stability: prefer-lowest
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
-          - os: ubuntu-latest
-            php: 8.1
-            laravel: 9.*
-            testbench: 7.*
-            carbon: ^2.63
-            pest: ^1.23
-            pest_laravel: ^1.4
-            pest_arch: none
-            collision: ^6.4
-            stability: prefer-stable
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          # Skipped as incompatible:
+          # - Laravel 9 on PHP 8.3, 8.4, 8.5: Laravel 9 test stack uses PHPUnit 9/Pest 1.
+          # - Laravel 10 on PHP 8.0: Laravel 10 requires PHP 8.1+.
+          # - Laravel 10 on PHP 8.4, 8.5: Pest 2/Paratest 7.3 for Laravel 10 does not support PHP 8.4+.
+          # - Laravel 11 and 12 on PHP 8.0, 8.1: Laravel 11/12 test stacks require PHP 8.2+.
+          # - Laravel 13 on PHP 8.0, 8.1, 8.2: Laravel 13/Testbench 11 require PHP 8.3+.
           - os: ubuntu-latest
             php: 8.0
             laravel: 9.*
             testbench: 7.*
             carbon: ^2.63
+            collision: ^6.4
             pest: ^1.23
             pest_laravel: ^1.4
             pest_arch: none
-            collision: ^6.4
             stability: prefer-lowest
             test_command: vendor/bin/pest --ci tests/ExampleTest.php
           - os: ubuntu-latest
@@ -95,12 +35,276 @@ jobs:
             laravel: 9.*
             testbench: 7.*
             carbon: ^2.63
+            collision: ^6.4
             pest: ^1.23
             pest_laravel: ^1.4
             pest_arch: none
-            collision: ^6.4
             stability: prefer-stable
             test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            collision: ^6.4
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            collision: ^6.4
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            collision: ^6.4
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            collision: ^6.4
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            collision: ^7.8
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.5
+            laravel: 11.*
+            testbench: 9.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 12.*
+            testbench: 10.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 12.*
+            testbench: 10.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 12.*
+            testbench: 10.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 12.*
+            testbench: 10.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.5
+            laravel: 12.*
+            testbench: 10.*
+            carbon: ^2.72
+            collision: ^8.9.1
+            pest: ^3.8.2
+            pest_laravel: ^3.2
+            pest_arch: ^3.1
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
+            collision: ^8.9.4
+            pest: ^4.4.1
+            pest_laravel: ^4.1
+            pest_arch: ^4.0
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.3
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
+            collision: ^8.9.4
+            pest: ^4.4.1
+            pest_laravel: ^4.1
+            pest_arch: ^4.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.4
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
+            collision: ^8.9.4
+            pest: ^4.4.1
+            pest_laravel: ^4.1
+            pest_arch: ^4.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.5
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3.8
+            collision: ^8.9.4
+            pest: ^4.4.1
+            pest_laravel: ^4.1
+            pest_arch: ^4.0
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -122,10 +326,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ "${{ matrix.pest_arch }}" = "none" ]; then
-            composer remove pestphp/pest-plugin-arch --dev --no-interaction --no-update
-          fi
+          composer remove pestphp/pest-plugin-arch --dev --no-interaction --no-update
+          composer remove nunomaduro/larastan --dev --no-interaction --no-update
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" "nunomaduro/collision:${{ matrix.collision }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest_laravel }}" --dev --no-interaction --no-update
+          if [ "${{ matrix.pest_arch }}" != "none" ]; then
+            composer require "pestphp/pest-plugin-arch:${{ matrix.pest_arch }}" --dev --no-interaction --no-update
+          fi
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,14 +12,95 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        php: [8.2, 8.1]
-        laravel: [10.*]
-        stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 10.*
             testbench: 8.*
             carbon: ^2.63
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            collision: ^7.8
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.2
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            collision: ^7.8
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            collision: ^7.8
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 10.*
+            testbench: 8.*
+            carbon: ^2.63
+            pest: ^2.33.2 <2.33.3
+            pest_laravel: ^2.0
+            pest_arch: ^2.0
+            collision: ^7.8
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            collision: ^6.4
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.1
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            collision: ^6.4
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.0
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            collision: ^6.4
+            stability: prefer-lowest
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+          - os: ubuntu-latest
+            php: 8.0
+            laravel: 9.*
+            testbench: 7.*
+            carbon: ^2.63
+            pest: ^1.23
+            pest_laravel: ^1.4
+            pest_arch: none
+            collision: ^6.4
+            stability: prefer-stable
+            test_command: vendor/bin/pest --ci tests/ExampleTest.php
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -41,11 +122,14 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --dev --no-interaction --no-update
+          if [ "${{ matrix.pest_arch }}" = "none" ]; then
+            composer remove pestphp/pest-plugin-arch --dev --no-interaction --no-update
+          fi
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" "nunomaduro/collision:${{ matrix.collision }}" "pestphp/pest:${{ matrix.pest }}" "pestphp/pest-plugin-laravel:${{ matrix.pest_laravel }}" --dev --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
 
       - name: List Installed Dependencies
         run: composer show -D
 
       - name: Execute tests
-        run: vendor/bin/pest --ci
+        run: ${{ matrix.test_command }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -332,7 +332,9 @@ jobs:
           if [ "${{ matrix.pest_arch }}" != "none" ]; then
             composer require "pestphp/pest-plugin-arch:${{ matrix.pest_arch }}" --dev --no-interaction --no-update
           fi
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking --no-scripts
+          composer dump-autoload --no-interaction --no-scripts
+          perl -0pi -e 's#\n    <coverage>.*?</coverage>##s' phpunit.xml.dist
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.0
             laravel: 9.*
@@ -40,7 +40,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.1
             laravel: 9.*
@@ -51,7 +51,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.1
             laravel: 9.*
@@ -62,7 +62,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.2
             laravel: 9.*
@@ -73,7 +73,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.2
             laravel: 9.*
@@ -84,7 +84,7 @@ jobs:
             pest_laravel: ^1.4
             pest_arch: none
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci tests/ExampleTest.php
+            test_command: vendor/bin/pest tests/ExampleTest.php
           - os: ubuntu-latest
             php: 8.1
             laravel: 10.*
@@ -95,7 +95,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.1
             laravel: 10.*
@@ -106,7 +106,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 10.*
@@ -117,7 +117,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 10.*
@@ -128,7 +128,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 10.*
@@ -139,7 +139,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 10.*
@@ -150,7 +150,7 @@ jobs:
             pest_laravel: ^2.0
             pest_arch: ^2.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 11.*
@@ -161,7 +161,7 @@ jobs:
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 11.*
@@ -172,7 +172,7 @@ jobs:
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 11.*
@@ -183,7 +183,7 @@ jobs:
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.4
             laravel: 11.*
@@ -194,7 +194,7 @@ jobs:
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.5
             laravel: 11.*
@@ -205,62 +205,62 @@ jobs:
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 12.*
             testbench: 10.*
-            carbon: ^2.72
+            carbon: ^3.8.4
             collision: ^8.9.1
             pest: ^3.8.2
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.2
             laravel: 12.*
             testbench: 10.*
-            carbon: ^2.72
+            carbon: ^3.8.4
             collision: ^8.9.1
             pest: ^3.8.2
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 12.*
             testbench: 10.*
-            carbon: ^2.72
+            carbon: ^3.8.4
             collision: ^8.9.1
             pest: ^3.8.2
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.4
             laravel: 12.*
             testbench: 10.*
-            carbon: ^2.72
+            carbon: ^3.8.4
             collision: ^8.9.1
             pest: ^3.8.2
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.5
             laravel: 12.*
             testbench: 10.*
-            carbon: ^2.72
+            carbon: ^3.8.4
             collision: ^8.9.1
             pest: ^3.8.2
             pest_laravel: ^3.2
             pest_arch: ^3.1
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 13.*
@@ -271,7 +271,7 @@ jobs:
             pest_laravel: ^4.1
             pest_arch: ^4.0
             stability: prefer-lowest
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.3
             laravel: 13.*
@@ -282,7 +282,7 @@ jobs:
             pest_laravel: ^4.1
             pest_arch: ^4.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.4
             laravel: 13.*
@@ -293,7 +293,7 @@ jobs:
             pest_laravel: ^4.1
             pest_arch: ^4.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
           - os: ubuntu-latest
             php: 8.5
             laravel: 13.*
@@ -304,7 +304,7 @@ jobs:
             pest_laravel: ^4.1
             pest_arch: ^4.0
             stability: prefer-stable
-            test_command: vendor/bin/pest --ci
+            test_command: vendor/bin/pest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --dev --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-security-blocking
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/contracts": "^9.28 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/contracts": "^9.28 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^7.11",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.33.2 <2.33.3",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "pestphp/pest": "^2.35.1",
+        "pestphp/pest-plugin-arch": "^2.7",
+        "pestphp/pest-plugin-laravel": "^2.4",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nunomaduro/collision": "^7.8",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20 <2.33.3",
+        "pestphp/pest": "^2.33.2 <2.33.3",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "nunomaduro/collision": "^7.8",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.8",
-        "pestphp/pest": "^2.20",
+        "pestphp/pest": "^2.20 <2.33.3",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",


### PR DESCRIPTION
## Summary
- expand CI coverage for Laravel 9 through 13 across compatible PHP versions
- pin Pest/PHPUnit stacks per Laravel generation so dependency resolution works
- avoid install-time scripts and coverage warnings breaking matrix jobs

## Validation
- GitHub Actions matrix passed on fork